### PR TITLE
adds new flag for -no-header and -timeout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,8 +21,11 @@ jobs:
     - name: Build
       run: go build -v ./...
 
-    - name: Test
+    - name: Go Tests
       run: go test -v ./...
+
+    - name: CLI Tests
+      run: ./cli-test-suite.sh
 
     - uses: actions/upload-artifact@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,5 @@ COPY --from=builder /checkssl /checkssl
 ENTRYPOINT ["/checkssl"]
 
 
-# docker buildx build --platform linux/arm/v7,linux/arm64,linux/amd64 --tag szazeski/checkssl:0.5.0 --tag szazeski/checkssl:latest -push .
+# docker buildx build --platform linux/arm/v7,linux/arm64,linux/amd64 --tag szazeski/checkssl:0.5.1 --tag szazeski/checkssl:latest --push .
+# you may need to do a `docker buildx create --use`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ https://ebay.com stopped after 10 redirects
 
 `-short` will reduce each target's output to just the pass/fail line with the url/dns.
 
+`-no-headers` will remove the csv header line from the output
+
+`-timeout=5` will set the timeout to 5 seconds [default is 15]
+
 
 ### Return Codes
 
@@ -76,7 +80,7 @@ https://ebay.com stopped after 10 redirects
 
 ### Linux/Mac
 ```
-wget https://github.com/szazeski/checkssl/releases/download/v0.5.1/checkssl_$(uname -s)_$(uname -m).tar.gz -O checkssl.tar.gz && tar -xf checkssl.tar.gz && chmod +x checkssl && sudo mv checkssl /usr/local/bin/
+wget https://github.com/szazeski/checkssl/releases/download/v0.6.0/checkssl_$(uname -s)_$(uname -m).tar.gz -O checkssl.tar.gz && tar -xf checkssl.tar.gz && chmod +x checkssl && sudo mv checkssl /usr/local/bin/
 ```
 
 ### Docker
@@ -92,7 +96,7 @@ wget https://github.com/szazeski/checkssl/releases/download/v0.5.1/checkssl_$(un
 ### Windows (Powershell)
 
 ```
-Invoke-WebRequest https://github.com/szazeski/checkssl/releases/download/v0.5.1/checkssl_Windows_x86_64.tar.gz -outfile checkssl.tar.gz; tar -xzf checkssl.tar.gz; echo "if you want, move the file to a PATH directory like WINDOWS folder"
+Invoke-WebRequest https://github.com/szazeski/checkssl/releases/download/v0.6.0/checkssl_Windows_x86_64.tar.gz -outfile checkssl.tar.gz; tar -xzf checkssl.tar.gz; echo "if you want, move the file to a PATH directory like WINDOWS folder"
 ```
 
 then move to `C:\Windows\` or other PATH directory 

--- a/cli-test-suite.sh
+++ b/cli-test-suite.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+TEST_PASS=0
+TEST_FAIL=0
+function failtest() {
+    TEST_FAIL=$((TEST_FAIL+1))
+    echo "[FAIL] $1"
+}
+function passtest() {
+    TEST_PASS=$((TEST_PASS+1))
+    echo "[PASS] $1"
+}
+
+echo "cli-test-suite.sh"
+echo "  This suite tests functionality of the locally built ./checkssl"
+
+if [ ! -f ./checkssl ]; then
+    echo "  ./checkssl does not exist, attempting to build one"
+    go build
+    if [ ! -f ./checkssl ]; then
+        echo "  ./checkssl still does not exist, [FAIL] test"
+        exit 1
+    fi
+fi
+
+OUTPUT=$(./checkssl)
+EXPECTED=$(cat <<-END
+checkssl [url] [url] [url] ...
+ easy to read/parse information about ssl certificates
+ version 0.6.0 built 2024-Aug-5
+  -days=5 (will fail the check if the cert is within 5 days of renewal)
+  -json (will output in JSON format)
+  -csv (will output in comma seperated format for spreadsheets)
+  -no-color (will disable color syntax from output)
+  -no-output (will only produce exit code)
+  -no-header (will disable the header row in CSV output)
+  -short (will show only 1 line per result)
+  -timeout=5 (will set the timeout to 5 seconds)  default = 15
+END
+)
+diff <(echo "$OUTPUT") <(echo "$EXPECTED") && passtest "blank input matches" || failtest "blank input does not match"
+
+
+# TODO version check
+
+
+./checkssl checkssl.org -no-output
+if [ $? -eq 0 ]; then
+    passtest "checkssl.org is valid today"
+else
+    failtest "expected checkssl.org today to be valid"
+fi
+
+
+./checkssl checkssl.org -no-output -days=500
+if [ $? -eq 0 ]; then
+    failtest "checkssl.org in 500 days should be expired"
+else
+    passtest "checkssl.org shows expired in 500 days"
+fi
+
+# 192.168.200.200 is a private ip that shouldn't exist
+./checkssl 192.168.200.200 -no-output -timeout=1
+if [ $? -eq 0 ]; then
+    failtest "timeout url passed but it should not have"
+else
+    passtest "timeout url does not pass"
+fi
+
+./checkssl expired.badssl.com -no-output
+if [ $? -eq 0 ]; then
+    failtest "expired url passed but it should not have"
+else
+    passtest "expired url does not pass"
+fi
+
+
+
+
+if [ $TEST_FAIL -eq 0 ]; then
+    echo "ALL tests passed"
+    exit 0
+else
+    echo "$TEST_FAIL tests failed"
+    exit 1
+fi

--- a/lib/checkssl/checkssl_test.go
+++ b/lib/checkssl/checkssl_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func Test_CheckServer_Blank(t *testing.T) {
-	actual := CheckServer("", time.Now(), false)
+	checkssl := NewCheckSSL()
+	actual := checkssl.CheckServer("", false)
 
 	if actual.Passed != false {
 		t.Fatal("no target should of produced a failing response")
@@ -16,7 +17,8 @@ func Test_CheckServer_Blank(t *testing.T) {
 }
 
 func Test_CheckServer_checksslorg(t *testing.T) {
-	actual := CheckServer("checkssl.org", time.Now(), false)
+	checker := NewCheckSSL()
+	actual := checker.CheckServer("checkssl.org", false)
 
 	if !actual.Passed {
 		t.Fatal("expecting to get a passing reply")
@@ -45,7 +47,8 @@ func Test_CheckServer_pinningTest(t *testing.T) {
 	testFailure(t, "https://pinning-test.badssl.com/")
 }
 func testFailure(t *testing.T, target string) {
-	actual := CheckServer(target, time.Now(), false)
+	checker := NewCheckSSL()
+	actual := checker.CheckServer(target, false)
 
 	if actual.Passed {
 		t.Fatal("expecting to get a failure reply")

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	VERSION        = "0.5.1"
-	BUILD_DATE     = "2024-Apr-21"
+	VERSION        = "0.6.0"
+	BUILD_DATE     = "2024-Aug-5"
 	FLAG_DAYS      = "-days="
 	FLAG_JSON      = "-json"
 	FLAG_CSV       = "-csv"


### PR DESCRIPTION
### Issue
 - https://github.com/szazeski/checkssl/issues/7

### Description

Adds `-no-header` to remove the csv header from the output

Adds `-timeout=2` to let the user set what the timeout should be

### Testing